### PR TITLE
remove unnecessary crypto package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
   "name": "ucoz-uapi",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Node JS модуль для uAPI",
   "main": "index.js",
   "directories": {
     "test": "test"
   },
   "dependencies": {
-    "crypto": "^0.0.3",
     "lodash": "^3.10.1",
     "querystring": "^0.2.0",
     "request": "^2.60.0"


### PR DESCRIPTION
See https://medium.com/@rmehlinger/crypto-collision-f41c206de27b. This package has no license and no tests, and masks a built in NodeJS library. Thankfully, Node does not allow its crypto package to be overwritten by this thing, so requiring it doesn't actually do anything.